### PR TITLE
Add install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,10 @@
+#!/bin/zsh
+
+# `install.sh` が存在する絶対パスを取得。
+# これによってどこから実行しても目的のファイルへの alias が貼られる。
+DOTPATH=$(cd $(dirname $0); pwd)
+
+ln -sf $DOTPATH/tmux.conf $HOME/tmux.conf
+ln -sf $DOTPATH/vimrc $HOME/.vimrc
+ln -sf $DOTPATH/zshrc $HOME/.zshrc
+


### PR DESCRIPTION
alias を貼るスクリプトを追加。

`ln` (link) コマンドによって alias を貼っている。

```shell
DOTPATH=$(cd $(dirname $0); pwd)
```

によって、どのディレクトリから実行されても (dotfiles をどこに配置してあっても) 目的のファイルへの alias が貼れるようにしている。