### PR TITLE
Add Brewfile

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,126 @@
+tap "daipeihust/tap"
+tap "danger/tap"
+tap "delphinus/sfmono-square"
+tap "homebrew/bundle"
+tap "homebrew/cask"
+tap "homebrew/cask-drivers"
+tap "homebrew/cask-fonts"
+tap "homebrew/cask-versions"
+tap "homebrew/core"
+tap "homebrew/services"
+brew "node"
+brew "bitwarden-cli"
+brew "carthage"
+brew "colordiff"
+brew "gnutls"
+brew "ffmpeg"
+brew "fzf"
+brew "gh"
+brew "git"
+brew "goenv", args: ["HEAD"]
+brew "graphviz"
+brew "hugo"
+brew "imagemagick"
+brew "jenv"
+brew "mas"
+brew "mint"
+brew "neovim"
+brew "openjdk"
+brew "ruby-build"
+brew "rbenv"
+brew "rbenv-communal-gems"
+brew "reattach-to-user-namespace"
+brew "ruby"
+brew "rustup-init"
+brew "tig"
+brew "tmux"
+brew "tree"
+brew "vim"
+brew "xcenv"
+brew "daipeihust/tap/im-select"
+brew "delphinus/sfmono-square/sfmono-square"
+cask "alfred"
+cask "android-studio"
+cask "anki"
+cask "appcode"
+cask "authy"
+cask "betterdisplay"
+cask "bettertouchtool"
+cask "bitwarden"
+cask "blue-sherpa"
+cask "charles"
+cask "dash"
+cask "discord"
+cask "docker"
+cask "emacs"
+cask "figma"
+cask "flutter"
+cask "font-hack-nerd-font"
+cask "font-mplus"
+cask "fork"
+cask "google-chrome"
+cask "google-japanese-ime"
+cask "hammerspoon"
+cask "insomnia"
+cask "iterm2"
+cask "karabiner-elements"
+cask "keyboard-cleaner"
+cask "keyboard-maestro"
+cask "keyboardcleantool"
+cask "keycastr"
+cask "kindle"
+cask "logitech-options"
+cask "meetingbar"
+cask "microsoft-auto-update"
+cask "microsoft-excel"
+cask "microsoft-powerpoint"
+cask "microsoft-word"
+cask "mos"
+cask "nightowl"
+cask "notion"
+cask "obs"
+cask "obsidian"
+cask "proxyman"
+cask "qlcolorcode"
+cask "qlimagesize"
+cask "qlmarkdown"
+cask "qlprettypatch"
+cask "qlstephen"
+cask "qmk-toolbox"
+cask "quicklook-csv"
+cask "quicklook-json"
+cask "sf-symbols"
+cask "shifty"
+cask "the-unarchiver"
+cask "toggl-track"
+cask "visual-studio-code"
+cask "vlc"
+cask "webpquicklook"
+cask "xcodes"
+cask "zeplin"
+cask "zoom"
+mas "AdGuard for Safari", id: 1440147259
+mas "Bitwarden", id: 1352778147
+mas "CopyLinkToPasteboard", id: 1551527433
+mas "CotEditor", id: 1024640650
+mas "DaVinci Resolve", id: 571213070
+mas "Dropover", id: 1355679052
+mas "GarageBand", id: 682658836
+mas "GoodNotes", id: 1444383602
+mas "Hidden Bar", id: 1452453066
+mas "iMovie", id: 408981434
+mas "Keynote", id: 409183694
+mas "Numbers", id: 409203825
+mas "OctoLinker", id: 1549308269
+mas "Octotree", id: 1457450145
+mas "Pages", id: 409201541
+mas "PiPifier", id: 1160374471
+mas "Playgrounds", id: 1496833156
+mas "Refined GitHub", id: 1519867270
+mas "Slack", id: 803453959
+mas "Structured", id: 1499198946
+mas "Things", id: 904280696
+mas "Transporter", id: 1450874784
+mas "URL Linker", id: 1289119450
+mas "Vimari", id: 1480933944
+mas "Vinegar", id: 1591303229


### PR DESCRIPTION
`Brewfile` を追加。

`Brewfile` 自体は

```shell
brew bundle dump
```

によって生成できる。
c.f. [brew(1) – The Missing Package Manager for macOS (or Linux) — Homebrew Documentation](https://docs.brew.sh/Manpage#bundle-subcommand)